### PR TITLE
Bugfix: preserve template tags from Decap

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -14,7 +14,9 @@ collections:
     label: "Blog" # Used in the UI
     folder: "blog/_posts" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
+    {% raw %}
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
+    {% endraw %}
     fields: # The fields for each document, usually in front matter
       - {label: "Layout", name: "layout", widget: "hidden", default: "post"}
       - {label: "Title", name: "title", widget: "string"}
@@ -68,7 +70,9 @@ collections:
   - name: "authors"
     label: "Authors"
     folder: "_authors/"
+    {% raw %}
     slug: "{{name}}"
+    {% endraw %}
     output: true
     create: true
     editor:


### PR DESCRIPTION
With #110, I introduced Jekyll processing to the `admin/config.yml` file so that the tags `select` widget could have its options populated from `site.tags`, which come from the Jekyll site.

However, I failed to see that Decap CMS also uses double curly-braces for its [template tags](https://decapcms.org/docs/configuration-options/#slug). As a result, anywhere in the admin config that was using those got clobbered away by Jekyll processing.

This PR fixes it by wrapping those parts with the [`{% raw %}`](https://shopify.github.io/liquid/tags/template/) tag from Liquid.